### PR TITLE
Added CURLOPT_HTTPGET to Request::get()

### DIFF
--- a/Economic/API/Request.php
+++ b/Economic/API/Request.php
@@ -51,7 +51,7 @@ class Request
         $this->setUrl($path);
 
         // Make sure to reset CURL headers back to GET.
-        curl_setopt($this->client->ch, CURLOPT_HTTPGET, TRUE);
+        curl_setopt($this->client->ch, CURLOPT_HTTPGET, true);
 
         // Start the request and return the response
         return $this->execute('GET');

--- a/Economic/API/Request.php
+++ b/Economic/API/Request.php
@@ -50,6 +50,9 @@ class Request
         // Set the request params
         $this->setUrl($path);
 
+        // Make sure to reset CURL headers back to GET.
+        curl_setopt($this->client->ch, CURLOPT_HTTPGET, TRUE);
+
         // Start the request and return the response
         return $this->execute('GET');
     }


### PR DESCRIPTION
Added CURLOPT_HTTPGET to Request::get() to make sure no content-length is sent on GET requests.

Adresses issue #4 